### PR TITLE
UPDATE vault dependency

### DIFF
--- a/lib/secrets_cli/vault/auth.rb
+++ b/lib/secrets_cli/vault/auth.rb
@@ -19,11 +19,11 @@ module SecretsCli
       def command
         case auth_method
         when 'github'
-          ::Vault.auth.github(auth_token).auth.policies
+          ::Vault.auth.github(auth_token).data[:policies]
         when 'token'
-          ::Vault.auth.token(auth_token).auth.policies
+          ::Vault.auth.token(auth_token).data[:policies]
         when 'app_id'
-          ::Vault.auth.app_id(auth_app_id, auth_user_id).auth.policies
+          ::Vault.auth.app_id(auth_app_id, auth_user_id).data[:policies]
         else
           error! "Unknown auth method #{auth_method}"
         end

--- a/secrets_cli.gemspec
+++ b/secrets_cli.gemspec
@@ -34,5 +34,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'commander'
   spec.add_runtime_dependency 'tty-prompt'
   spec.add_runtime_dependency 'tty-file'
-  spec.add_runtime_dependency 'vault', '~> 0.5.0'
+  spec.add_runtime_dependency 'vault', '~> 0.10.1'
 end


### PR DESCRIPTION
Vault is locked on version `0.5`, but it is not compatible with latest
vault version, so we need to update it to version `0.10`.

Details
* UPDATE vault dependency
* UPDATE code